### PR TITLE
Change keymap Dict types for Julia 1.6 compatibility

### DIFF
--- a/src/ReplMaker.jl
+++ b/src/ReplMaker.jl
@@ -66,7 +66,7 @@ function initrepl(parser::Function;
 
     mk = REPL.mode_keymap(julia_mode)
 
-    lang_keymap = Dict(
+    lang_keymap = Dict{Any,Any}(
     start_key => (s, args...) ->
       if isempty(s) || position(LineEdit.buffer(s)) == 0
         enter_mode!(s, lang_mode)

--- a/src/ReplMaker.jl
+++ b/src/ReplMaker.jl
@@ -75,7 +75,7 @@ function initrepl(parser::Function;
       end
     )
 
-    lang_mode.keymap_dict = LineEdit.keymap(Dict[
+    lang_mode.keymap_dict = LineEdit.keymap(Dict{Any,Any}[
         skeymap,
         mk,
         LineEdit.history_keymap,


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/37163 constrained the acceptable types for a REPL keymap from `Dict` to `Dict{Any,Any}` and `Dict{Char,Any}}`.

The changes here should provide a backwards-compatible fix