### PR TITLE
Fix current buffer copying in `enter_mode!`

### DIFF
--- a/src/ReplMaker.jl
+++ b/src/ReplMaker.jl
@@ -131,8 +131,8 @@ function enter_mode!(f, s :: LineEdit.MIState, lang_mode)
 end
 
 function enter_mode!(s :: LineEdit.MIState, lang_mode)
+  buf = copy(LineEdit.buffer(s))
   function default_trans_action()
-    buf = copy(LineEdit.buffer(s))
     LineEdit.state(s, lang_mode).input_buffer = buf
   end
   enter_mode!(default_trans_action, s, lang_mode)


### PR DESCRIPTION
The two argument version of `enter_mode!` is intended to allow REPL modes to
work like Julia's builtin REPL modes: when there is already partial input on
the prompt, and the user switches the mode, then the partial input is carried
forward to the new REPL mode.

However, the copy was done too late, in default_trans_action() instead of
before that closure is created and control handed off to LineEdit. This seems
to have been broken since a refactoring in August 2019.
