### PR TITLE
Support Ctrl/Alt-Key combos as start key

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,18 @@ Tada!
 </p>
 </details>
 
+# Modifier keys
+<details>
+ <summaryClick me! ></summary>
+<p>
+           
+Aritrary key combinations to enter REPL modes are not yet allowed, but you can currently use the `CTRL` and `ALT` (also known as `META`) keys as modifiers for entering REPL modes. For example, passing the keyword argument `start_key="\\C-g"` to the `initrepl` function will make it so that holding down on the `CTRL` key and pressing `g` enters the specified mode. 
+
+Likewise, specifying `start_key="\\M-u"` will make it so that holding `ALT` (aka `META`) and pressing `u` will enter the desired mode. 
+
+</p>
+</details>
+ 
 # Creating a REPL mode at startup time
 
 To add a custom REPL mode whenever Julia starts, add to `~/.julia/config/startup.jl` code like:

--- a/src/ReplMaker.jl
+++ b/src/ReplMaker.jl
@@ -30,6 +30,14 @@ your repl mode with `mode_name` and optionally provide a function which checks i
 before parsing with `valid_input_checker`. Autocompletion options are supplied through the argument
 `completion_provider` which defaults to the standard julia REPL TAB completions. `prompt_text` may either be a
 string or a zero-argument function which computes the prompt string.
+
+Aritrary key combinations to enter REPL modes are not yet allowed, but you can currently use the `CTRL` and `ALT` 
+(also known as `META`) keys as modifiers for entering REPL modes. For example, passing the keyword argument 
+`start_key="\\C-g"` to the `initrepl` function will make it so that holding down on the `CTRL` key and pressing 
+`g` enters the specified mode.
+
+Likewise, specifying `start_key="\\M-u"` will make it so that holding `ALT` (aka `META`) and pressing `u` will
+enter the desired mode.
 """
 function initrepl(parser::Function;
                   prompt_text = "myrepl> ",


### PR DESCRIPTION
This addresses issue #24 *partially*. One can not handle shift, nor are arbitrary combos possible. E.g. `Ctrl-,` is not supported.

