### PR TITLE
Revert "Allow use at startup within `atreplinit`"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ReplMaker"
 uuid = "b873ce64-0db9-51f5-a568-4457d8e49576"
 authors = ["MasonProtter <mason.protter@gmail.com>"]
-version = "0.2.6"
+version = "0.2.7"
 
 [deps]
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"

--- a/src/ReplMaker.jl
+++ b/src/ReplMaker.jl
@@ -60,9 +60,7 @@ function initrepl(parser::Function;
         repl = enablecustomdisplay(repl, show_function, show_function_io)
     end
 
-    repl.interface = REPL.setup_interface(repl)
     julia_mode = repl.interface.modes[1]
-
     prefix = repl.hascolor ? color : ""
     suffix = repl.hascolor ? (repl.envcolors ? Base.input_color : repl.input_color()) : ""
 


### PR DESCRIPTION
#30 seems to break ReplMaker completely for me. The first example in the readme doesn't work, for example.

So revert #30 for now and bump the version so we can have an emergency fix.

CC @IlyaOrson 